### PR TITLE
Added streamlit deploy and playwright tests

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -44,7 +44,7 @@ jobs:
 
     - name: Create secrets.toml file
       run: |
-        echo 'auth_password = "${{ secrets.AUTH_PASSWORD }}"'' >> .streamlit/secrets.toml
+        echo 'auth_password = "${{ secrets.AUTH_PASSWORD }}"' >> .streamlit/secrets.toml
 
     # TODO: Add deployment step to deploy streamlit app on current commit to public URL.continue-on-error: 
     - name: Deploy streamlit app

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4
@@ -53,9 +53,8 @@ jobs:
         app-path: "src/dashboard/main.py"
         ruff: true
 
-    - name: Run functional tests
-      uses: OctoMind-dev/automagically-action-execute@v2
-      with:
-        url: https://viking.streamlit.app/
-        token: ${{ secrets.OCTOMIND_ORGANISATION_KEY }}
-        testTargetId: ${{ secrets.OCTOMIND_TEST_TARGET }}
+    - name: Run Playwright tests
+      env:
+        DASHBOARD_USERNAME: ${{ secrets.DASHBOARD_USERNAME }}
+        DASHBOARD_PASSWORD: ${{ secrets.DASHBOARD_PASSWORD }}
+      run: pytest test/test_dashboard.py

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -42,6 +42,11 @@ jobs:
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
+    - name: Create secrets.toml file
+      run: |
+        echo "[secrets]" > .streamlit/secrets.toml
+        echo "auth_password = '${{ secrets.AUTH_PASSWORD }}'" >> .streamlit/secrets.toml
+
     # TODO: Add deployment step to deploy streamlit app on current commit to public URL.continue-on-error: 
     - name: Deploy streamlit app
       uses: streamlit/streamlit-app-action@v0.0.3

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -44,8 +44,7 @@ jobs:
 
     - name: Create secrets.toml file
       run: |
-        echo "[secrets]" > .streamlit/secrets.toml
-        echo "auth_password = '${{ secrets.AUTH_PASSWORD }}'" >> .streamlit/secrets.toml
+        echo 'auth_password = "${{ secrets.AUTH_PASSWORD }}"'' >> .streamlit/secrets.toml
 
     # TODO: Add deployment step to deploy streamlit app on current commit to public URL.continue-on-error: 
     - name: Deploy streamlit app

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -27,7 +27,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install wheel build setuptools flake8 pytest
+        python -m pip install wheel build setuptools flake8
+        python -m playwright install
 
     - name: Build
       run: python -m build

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install wheel build setuptools flake8
+        python -m pip install wheel build setuptools flake8 pytest pytest-playwright
         python -m playwright install
 
     - name: Build

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -47,12 +47,19 @@ jobs:
       run: |
         echo 'auth_password = "${{ secrets.AUTH_PASSWORD }}"' >> .streamlit/secrets.toml
 
-    # TODO: Add deployment step to deploy streamlit app on current commit to public URL.continue-on-error: 
-    - name: Deploy streamlit app
-      uses: streamlit/streamlit-app-action@v0.0.3
-      with:
-        app-path: "src/dashboard/main.py"
-        ruff: true
+    - name: Start Streamlit app
+      run: |
+        nohup streamlit run src/dashboard/main.py &
+
+    - name: Wait for Streamlit app to be accessible
+      run: |
+        # Wait for Streamlit to start
+        for i in {1..30}; do
+          if curl -s http://localhost:8501; then
+            break
+          fi
+          sleep 2
+        done
 
     - name: Run Playwright tests
       env:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -41,3 +41,17 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+
+    # TODO: Add deployment step to deploy streamlit app on current commit to public URL.continue-on-error: 
+    - name: Deploy streamlit app
+      uses: streamlit/streamlit-app-action@v0.0.3
+      with:
+        app-path: "src/dashboard/main.py"
+        ruff: true
+
+    - name: Run functional tests
+      uses: OctoMind-dev/automagically-action-execute@v2
+      with:
+        url: https://viking.streamlit.app/
+        token: ${{ secrets.OCTOMIND_ORGANISATION_KEY }}
+        testTargetId: ${{ secrets.OCTOMIND_TEST_TARGET }}

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,8 @@ pymongo[srv]~=4.7.0
 streamlit~=1.35.0
 tqdm~=4.66.0
 xlsxwriter~=3.2.0
+
+# Development.
+playwright~=1.44.0
+pytest~=8.2.0
+pytest-playwright~=0.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,5 +11,6 @@ xlsxwriter~=3.2.0
 
 # Development.
 playwright~=1.44.0
+python-dotenv~=1.0.0
 pytest~=8.2.0
 pytest-playwright~=0.5.0

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ class PostInstallCommand(install):
 
 setup(
     name="viking-log-keeper",
-    version="1.3.2",
+    version="1.4.0",
     packages=find_packages(where="src"),
     package_dir={"": "src"},
     url="https://github.com/mjennings061/viking-log-keeper",

--- a/test/test_dashboard.py
+++ b/test/test_dashboard.py
@@ -1,0 +1,60 @@
+"""test_dashboard.py - Test cases for the dashboard module."""
+
+import os
+import pytest
+from dotenv import load_dotenv
+from playwright.sync_api import Page, expect
+
+# Load environment variables
+load_dotenv()
+dashboard_username = os.getenv("DASHBOARD_USERNAME")
+dashboard_password = os.getenv("DASHBOARD_PASSWORD")
+
+
+@pytest.fixture(scope="function")
+def setup(page: Page):
+    page.goto("http://localhost:8501")
+    yield page
+    # Close the page after the test.
+    page.close()
+    
+    
+@pytest.fixture(scope="function")
+def login(setup: Page):
+    page = setup
+    page.get_by_label("Username").click()
+    page.get_by_label("Username").fill(dashboard_username)
+    page.get_by_label("Password", exact=True).click()
+    page.get_by_label("Password", exact=True).fill(dashboard_password)
+    page.get_by_test_id("baseButton-secondaryFormSubmit").click()
+    yield page
+    # Close the page after the test.
+    page.close()
+
+
+def test_root_page(setup: Page):
+    # Check if the root page is loaded.
+    page = setup
+    expect(page.get_by_test_id("stForm")).to_be_visible()
+
+
+def test_dashboard_login(login: Page):
+    # Check if the dashboard page is loaded after login.
+    page = login
+
+    # Check if the dashboard page is loaded after login.
+    expect(page.get_by_role(
+        "heading", name="661VGS Dashboard"
+    )).to_be_visible()
+
+
+def test_example(login: Page) -> None:
+    page = login
+    page.get_by_role("img", name="open").first.click()
+    page.get_by_text("🌍 All Data").click()
+    expect(page.locator(".dvn-scroller")).to_be_visible()
+
+
+if __name__ == "__main__":
+    test_root_page()
+    test_dashboard_login()


### PR DESCRIPTION
Closes #26 

Added automated testing using playwright to test streamlit deploys and the user can be logged in

To copy this for future work, install requirements and run playwright codegen

```bash
python -m pip install --upgrade -r requirements.txt
python -m streamlit run src/dashboard/main.py
playwright install
playwright codegen localhost:8501
```