### PR TITLE
Fix pandas bug

### DIFF
--- a/src/dashboard/plots.py
+++ b/src/dashboard/plots.py
@@ -165,7 +165,7 @@ def plot_launches_by_commander(df: pd.DataFrame):
     # Display the chart in Streamlit.
     st.subheader("Launches by Pilot")
     st.text(f"Only pilots with {min_launches} or more launches shown.")
-    st.altair_chart(chart, use_container_width=True)
+    st.altair_chart(chart, width="stretch")
 
 
 def plot_firstlast_launch_table(df: pd.DataFrame):
@@ -254,7 +254,7 @@ def plot_longest_flight_times(df: pd.DataFrame):
 
     # Display the chart in Streamlit
     st.subheader("Longest Flight Times")
-    st.altair_chart(chart, use_container_width=True)
+    st.altair_chart(chart, width="stretch")
 
 
 def launches_by_type_table(df: pd.DataFrame):
@@ -423,7 +423,7 @@ def plot_duty_pie_chart(df: pd.DataFrame):
 
     # Display the pie chart in Streamlit
     st.subheader("Launches by Duty")
-    st.altair_chart(chart, use_container_width=True)
+    st.altair_chart(chart, width="stretch")
 
 
 def plot_monthly_launches(df: pd.DataFrame):
@@ -512,7 +512,7 @@ def plot_monthly_launches(df: pd.DataFrame):
 
     # Display the bar chart in Streamlit
     st.subheader("Monthly Launches")
-    st.altair_chart(final_chart, use_container_width=True)
+    st.altair_chart(final_chart, width="stretch")
 
 
 def table_all_launches(df: pd.DataFrame):
@@ -589,7 +589,7 @@ def table_all_launches(df: pd.DataFrame):
     df = df.reset_index(drop=True)
 
     # Plot all data.
-    st.dataframe(df, use_container_width=True)
+    st.dataframe(df, width="stretch")
 
 
 def show_logbook_helper(df: pd.DataFrame, commander: str):
@@ -624,7 +624,7 @@ def show_logbook_helper(df: pd.DataFrame, commander: str):
     display_df = format_data_for_table(filtered_df)
     st.header("Logbook Helper")
     st.text(f"Launches by {commander}")
-    st.dataframe(data=display_df, hide_index=True, use_container_width=True)
+    st.dataframe(data=display_df, hide_index=True, width="stretch")
 
 
 def quarterly_summary(df: pd.DataFrame, commander: str, quarter: str):
@@ -719,7 +719,7 @@ def show_logo(logo_path: Path):
     st.logo(str(logo_path))
     _, centre, _ = st.columns(3)
     with centre:
-        st.image(str(logo_path), use_container_width=True)
+        st.image(str(logo_path), width="stretch")
 
     # Show centred text.
     st.markdown(
@@ -885,7 +885,7 @@ def plot_gif_bar_chart(df: pd.DataFrame):
     # Display the chart in Streamlit.
     st.subheader("Cumulative GIFs Flown per Week")
     st.text(f"Financial Year: {year}")
-    st.altair_chart(chart, use_container_width=True)
+    st.altair_chart(chart, width="stretch")
 
 
 def get_aircraft_totals(aircraft_df: pd.DataFrame) -> pd.DataFrame:
@@ -992,11 +992,13 @@ def table_gur_summary(aircraft_df: pd.DataFrame, launches_df: pd.DataFrame):
     last_entry_df = last_entry_df.sort_values(by="Date", ascending=False)
     latest_week = last_entry_df.iloc[0]["Week Start"]
 
-    # Set totals columns to zero if they are not this week.
-    last_entry_df.loc[
-        last_entry_df["Week Start"] != latest_week,
-        ["Total Launches", "Total Flight Time"],
-    ] = 0
+    # Set totals columns to zero if they are not this week. Each column is set
+    # to a value matching its own dtype: "Total Launches" is numeric, while
+    # "Total Flight Time" is a formatted "H:MM" string (pandas 3.0 string dtype
+    # rejects assigning an integer).
+    not_latest_week = last_entry_df["Week Start"] != latest_week
+    last_entry_df.loc[not_latest_week, "Total Launches"] = 0
+    last_entry_df.loc[not_latest_week, "Total Flight Time"] = "0:00"
 
     # Sort by aircraft.
     last_entry_df = last_entry_df.sort_values(by="Aircraft")
@@ -1059,4 +1061,4 @@ def table_solo_dual_summary(df: pd.DataFrame, commander: str):
     # Display the table
     st.subheader(f"Solo/Dual Launch Summary for {commander}")
     st.text("SCT U/T launches only")
-    st.dataframe(summary_df, hide_index=True, use_container_width=True)
+    st.dataframe(summary_df, hide_index=True, width="stretch")

--- a/src/dashboard/weather_plots.py
+++ b/src/dashboard/weather_plots.py
@@ -208,7 +208,7 @@ def plot_flying_non_flying_violin(weather_df, selected_metric):
     )
 
     # Display the chart
-    st.altair_chart(violin, use_container_width=True)
+    st.altair_chart(violin, width="stretch")
 
 
 def plot_weather_vs_flight_time(weather_df, launches_df, selected_metric):
@@ -319,7 +319,7 @@ def plot_weather_vs_flight_time(weather_df, launches_df, selected_metric):
     ).mark_line(color="red")
 
     # Display the chart
-    st.altair_chart(scatter + trend, use_container_width=True)
+    st.altair_chart(scatter + trend, width="stretch")
 
 
 def plot_wind_polar(weather_df):
@@ -428,7 +428,7 @@ def weather_table(weather_df: pd.DataFrame):
 
     st.dataframe(
         display_df,
-        use_container_width=True,
+        width="stretch",
         hide_index=True,
         column_order=[
             "datetime",


### PR DESCRIPTION
Fix two bugs 

Closes #133 

```
For `use_container_width=True`, use `width='stretch'`. For `use_container_width=False`, use `width='content'` or specify an integer width.

2026-06-21 10:14:11.120 Please replace `use_container_width` with `width`.

`use_container_width` will be removed after 2025-12-31.

For `use_container_width=True`, use `width='stretch'`. For `use_container_width=False`, use `width='content'`.

2026-06-21 10:14:13.670 Please replace `use_container_width` with `width`.

`use_container_width` will be removed after 2025-12-31.

For `use_container_width=True`, use `width='stretch'`. For `use_container_width=False`, use `width='content'`.

26-06-21 10:14:13 main.py INFO: Displaying 661vgs dashboard.

26-06-21 10:14:13 get_config.py DEBUG: Collection log_sheets fetched.

26-06-21 10:14:14 main.py ERROR: Failed to display dashboard.

Traceback (most recent call last):

  File "/mount/src/viking-log-keeper/src/dashboard/main.py", line 447, in main

    show_data_dashboard(st.session_state["log_sheet_db"])

  File "/mount/src/viking-log-keeper/src/dashboard/main.py", line 283, in show_data_dashboard

    table_gur_summary(aircraft_df, df)

  File "/mount/src/viking-log-keeper/src/dashboard/plots.py", line 996, in table_gur_summary

    last_entry_df.loc[

  File "/home/adminuser/venv/lib/python3.12/site-packages/pandas/core/indexing.py", line 938, in __setitem__

    iloc._setitem_with_indexer(indexer, value, self.name)

  File "/home/adminuser/venv/lib/python3.12/site-packages/pandas/core/indexing.py", line 1953, in _setitem_with_indexer

    self._setitem_with_indexer_split_path(indexer, value, name)

  File "/home/adminuser/venv/lib/python3.12/site-packages/pandas/core/indexing.py", line 2044, in _setitem_with_indexer_split_path

    self._setitem_single_column(loc, value, pi)

  File "/home/adminuser/venv/lib/python3.12/site-packages/pandas/core/indexing.py", line 2181, in _setitem_single_column

    self.obj._mgr.column_setitem(loc, plane_indexer, value)

  File "/home/adminuser/venv/lib/python3.12/site-packages/pandas/core/internals/managers.py", line 1528, in column_setitem

    new_mgr = col_mgr.setitem((idx,), value)

              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/home/adminuser/venv/lib/python3.12/site-packages/pandas/core/internals/managers.py", line 607, in setitem

    return self.apply("setitem", indexer=indexer, value=value)

           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/home/adminuser/venv/lib/python3.12/site-packages/pandas/core/internals/managers.py", line 445, in apply

    applied = getattr(b, f)(**kwargs)

              ^^^^^^^^^^^^^^^^^^^^^^^

  File "/home/adminuser/venv/lib/python3.12/site-packages/pandas/core/internals/blocks.py", line 1667, in setitem

    values[indexer] = value

    ~~~~~~^^^^^^^^^

  File "/home/adminuser/venv/lib/python3.12/site-packages/pandas/core/arrays/arrow/array.py", line 2237, in __setitem__

    value = self._maybe_convert_setitem_value(value)

            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/home/adminuser/venv/lib/python3.12/site-packages/pandas/core/arrays/string_arrow.py", line 287, in _maybe_convert_setitem_value

    raise TypeError(

TypeError: Invalid value '0' for dtype 'str'. Value should be a string or missing value, got 'int' instead.
```