### PR TITLE
138 export a pre filled 2965d

### DIFF
--- a/src/dashboard/main.py
+++ b/src/dashboard/main.py
@@ -44,7 +44,9 @@ from dashboard.weather import weather_page  # noqa: E402
 from dashboard.utils import (   # noqa: E402
     LOGO_PATH,
     upload_log_sheets,
-    date_filter
+    date_filter,
+    get_prefilled_log_sheet,
+    update_template_from_upload,
 )
 
 
@@ -145,6 +147,77 @@ def refresh_data():
     st.toast("Data Refreshed!", icon="✅")
 
 
+def show_log_sheets_page(db: Database, aircraft_df: pd.DataFrame):
+    """Render Log Sheets page: pre-filled download, template update and sheet upload.
+
+    Args:
+        db (Database): The VGS database class.
+        aircraft_df (pd.DataFrame): Aircraft info for the brought-forward
+            lookup and the aircraft drop-down."""
+    # Download a pre-filled 2965D for a chosen aircraft.
+    st.subheader("⬇️ Download pre-filled log sheet")
+    known_aircraft = (
+        sorted(aircraft_df["Aircraft"].dropna().unique())
+        if not aircraft_df.empty else []
+    )
+    chosen = st.selectbox(
+        "Aircraft",
+        known_aircraft,
+        index=None,
+        accept_new_options=True,
+        placeholder="Select or type an aircraft, e.g. ZE683",
+        key="prefill_aircraft",
+        help="Pick a known aircraft or type a new tail number.",
+    )
+    if chosen:
+        result = get_prefilled_log_sheet(
+            db, chosen.strip().upper(), aircraft_df)
+        if result:
+            data, filename = result
+            st.download_button(
+                "Download pre-filled log sheet",
+                data=data,
+                file_name=filename,
+                mime="application/vnd.openxmlformats-officedocument."
+                     "spreadsheetml.sheet",
+                key="download_prefilled",
+            )
+
+    # Replace the stored template (holds squadron-specific INPUT_DATA).
+    with st.expander("⚙️ Update log sheet template"):
+        template_file = st.file_uploader(
+            "Upload a new 2965D template (.xltx/.xlsx) with the "
+            "INPUT_DATA sheet filled in.",
+            type=["xltx", "xlsx"],
+            key="template_upload",
+        )
+        if template_file and st.button("Store template", key="store_template"):
+            update_template_from_upload(db, template_file)
+
+    st.divider()
+
+    # Upload completed log sheets.
+    st.subheader("⬆️ Upload completed log sheets")
+    files = st.file_uploader(
+        "Upload log sheets below. Existing files will be updated.",
+        type=["xlsx"],
+        accept_multiple_files=True,
+        key="upload_log_sheets",
+        on_change=None,
+        help="Upload the log sheets to update the dashboard.",
+    )
+
+    if files:
+        # Upload the log sheets and refresh data.
+        success = upload_log_sheets(files)
+        refresh_data()
+        # Only redirect on a successful upload.
+        if success:
+            # Flag a redirect to the stats page.
+            st.session_state["redirect_to_stats"] = True
+            st.rerun()
+
+
 def show_data_dashboard(db: Database):
     """Display the dashboard.
 
@@ -156,7 +229,7 @@ def show_data_dashboard(db: Database):
     st.title(f"{vgs} Dashboard")
 
     # Sidebar for page navigation
-    pages = ["📈 Statistics", "📁 Upload Log Sheets",
+    pages = ["📈 Statistics", "📁 Log Sheets",
              "🧮 Stats & GUR Helper", "⛅ Weather", "🌍 All Data"]
     # Honour a redirect after a log sheet upload before the widget is instantiated.
     if st.session_state.pop("redirect_to_stats", False):
@@ -303,26 +376,8 @@ def show_data_dashboard(db: Database):
         case "⛅ Weather":
             weather_page(db, filtered_df)
 
-        case "📁 Upload Log Sheets":
-            # Display the upload log sheets page.
-            files = st.file_uploader(
-                "Upload log sheets below. Existing files will be updated.",
-                type=["xlsx"],
-                accept_multiple_files=True,
-                key="upload_log_sheets",
-                on_change=None,
-                help="Upload the log sheets to update the dashboard.",
-            )
-
-            if files:
-                # Upload the log sheets and refresh data.
-                success = upload_log_sheets(files)
-                refresh_data()
-                # Only redirect on a successful upload.
-                if success:
-                    # Flag a redirect to the stats page.
-                    st.session_state["redirect_to_stats"] = True
-                    st.rerun()
+        case "📁 Log Sheets":
+            show_log_sheets_page(db, aircraft_df)
 
 
 def login(username: str, password: str):

--- a/src/dashboard/main.py
+++ b/src/dashboard/main.py
@@ -156,10 +156,16 @@ def show_log_sheets_page(db: Database, aircraft_df: pd.DataFrame):
             lookup and the aircraft drop-down."""
     # Download a pre-filled 2965D for a chosen aircraft.
     st.subheader("⬇️ Download pre-filled log sheet")
-    known_aircraft = (
-        sorted(aircraft_df["Aircraft"].dropna().unique())
-        if not aircraft_df.empty else []
-    )
+    if not aircraft_df.empty:
+        # Only offer the most recently flown aircraft.
+        recent = (
+            aircraft_df.dropna(subset=["Date", "Aircraft"])
+            .sort_values("Date", ascending=False)
+            .drop_duplicates("Aircraft")
+        )
+        known_aircraft = sorted(recent["Aircraft"].head(6))
+    else:
+        known_aircraft = []
     chosen = st.selectbox(
         "Aircraft",
         known_aircraft,

--- a/src/dashboard/utils.py
+++ b/src/dashboard/utils.py
@@ -4,13 +4,17 @@ import logging
 import pandas as pd
 from pathlib import Path
 import streamlit as st
-from typing import List
+from typing import List, Sequence
 from io import BytesIO
 from datetime import date, timedelta, datetime
 
 # User defined modules.
 from log_keeper.ingest import ingest_log_sheet_from_upload, sanitise_log_sheets
-from log_keeper.output import update_launches_collection, update_aircraft_info
+from log_keeper.output import (
+    update_launches_collection,
+    update_aircraft_info,
+    fill_log_sheet,
+)
 
 # Get the logger instance.
 logger = logging.getLogger(__name__)
@@ -164,11 +168,11 @@ def validate_log_sheet(file: BytesIO) -> bool:
     return True
 
 
-def upload_log_sheets(files: List[BytesIO]) -> bool:
+def upload_log_sheets(files: Sequence[BytesIO]) -> bool:
     """Upload multiple log sheets to the database.
 
     Args:
-        files (List[BytesIO]): The log sheet files to upload.
+        files (Sequence[BytesIO]): The log sheet files to upload.
 
     Returns:
         bool: True if the upload to the database succeeded, False otherwise."""
@@ -243,6 +247,89 @@ def upload_log_sheets(files: List[BytesIO]) -> bool:
             status_text.update(label="Failed to upload log sheets.",
                                state="error", expanded=True)
             return False
+
+
+def get_prefilled_log_sheet(db, aircraft: str, aircraft_df: pd.DataFrame):
+    """Build a pre-filled 2965D log sheet for an aircraft.
+
+    Args:
+        db (Database): The VGS database.
+        aircraft (str): Aircraft number, e.g. "ZE683".
+        aircraft_df (pd.DataFrame): Aircraft info (already in session state).
+
+    Returns:
+        tuple[bytes, str] | None: (file bytes, filename), or None if no template
+        is stored."""
+    template = db.get_template()
+    if not template:
+        st.warning("No log sheet template stored yet. Use 'Update log sheet "
+                   "template' below to add one.")
+        return None
+
+    # Most recent brought-forward totals for this aircraft, if it has any.
+    launches_bf = hours_bf = None
+    if not aircraft_df.empty:
+        rows = aircraft_df[aircraft_df["Aircraft"] == aircraft]
+        if not rows.empty:
+            row = rows.iloc[0]  # aircraft_df is sorted by Date descending.
+            # Nullable UInt32 columns hold pd.NA, which int() can't convert;
+            if pd.notna(row["Launches After"]) and pd.notna(row["Hours After"]):
+                launches_bf = int(row["Launches After"])
+                hours_bf = int(row["Hours After"])
+
+    today = date.today()
+    if launches_bf is None:
+        st.info(f"No brought-forward data for {aircraft} — Launches B/F and "
+                "Hours B/F will be left blank.")
+    else:
+        st.caption(f"Launches B/F: {launches_bf}  |  Hours B/F: "
+                   f"{format_minutes_to_HHHH_mm(hours_bf)}  |  "
+                   f"Date: {today:%d %b %y}")
+
+    data = fill_log_sheet(template, aircraft, launches_bf, hours_bf, today)
+    return data, f"2965D_{today:%y%m%d}_{aircraft}.xlsx"
+
+
+def update_template_from_upload(db, uploaded_file) -> bool:
+    """Validate an uploaded 2965D template and store it in the database.
+
+    Args:
+        db (Database): The VGS database.
+        uploaded_file (BytesIO): The uploaded template (.xltx/.xlsx).
+
+    Returns:
+        bool: True if the template was stored, False otherwise."""
+    REQUIRED_SHEETS = {"2965D", "FORMATTED", "_AIRCRAFT", "INPUT_DATA"}
+    MAX_FILE_SIZE = 2 * 1024 * 1024  # 2 MB
+
+    if not uploaded_file.name.endswith((".xltx", ".xlsx")):
+        st.warning("Template must be a .xltx or .xlsx file.")
+        return False
+    if uploaded_file.size > MAX_FILE_SIZE:
+        st.warning(f"Template too large: {uploaded_file.size} bytes.")
+        return False
+
+    # Validate it is a real workbook with the sheets the pipeline relies on.
+    data = uploaded_file.getvalue()
+    try:
+        with pd.ExcelFile(BytesIO(data), engine="openpyxl") as xls:
+            missing = REQUIRED_SHEETS - set(map(str, xls.sheet_names))
+    except Exception:  # pylint: disable=broad-except
+        st.warning("Could not read the template as an Excel file.")
+        return False
+    if missing:
+        st.warning("Template is missing required sheets: "
+                   f"{', '.join(sorted(missing))}.")
+        return False
+
+    try:
+        db.update_template(data, uploaded_file.name)
+    except Exception:  # pylint: disable=broad-except
+        logger.error("Failed to store the template.", exc_info=True)
+        st.error("Failed to store the template.")
+        return False
+    st.toast("Log sheet template updated!", icon="✅")
+    return True
 
 
 def gifs_flown_per_day(df: pd.DataFrame) -> pd.DataFrame:

--- a/src/log_keeper/get_config.py
+++ b/src/log_keeper/get_config.py
@@ -158,6 +158,7 @@ class Database:
         self.launches_collection = "log_sheets"
         self.aircraft_info_collection = "aircraft"
         self.weather_collection = "weather"
+        self.template_collection = "template"
         # Validate client.
         if not client.authenticated():
             raise ConnectionError("Could not log in to the database.")
@@ -272,6 +273,36 @@ class Database:
             logger.error("Could not fetch data from aircraft collection.")
             df = pd.DataFrame()
         return df
+
+    def get_template(self) -> Optional[bytes]:
+        """Get the stored 2965D log sheet template.
+
+        Returns:
+            Optional[bytes]: The template file bytes, or None if not set."""
+        try:
+            doc = self.db[self.template_collection].find_one({"name": "2965D"})
+        except Exception:  # pylint: disable=broad-except
+            logger.exception("Could not fetch the log sheet template.")
+            return None
+        return bytes(doc["data"]) if doc and "data" in doc else None
+
+    def update_template(self, data: bytes, filename: str) -> None:
+        """Replace the stored 2965D log sheet template.
+
+        Args:
+            data (bytes): The template file bytes.
+            filename (str): The original filename, kept for display."""
+        self.db[self.template_collection].replace_one(
+            {"name": "2965D"},
+            {
+                "name": "2965D",
+                "filename": filename,
+                "data": data,
+                "uploaded_at": datetime.now(),
+            },
+            upsert=True,
+        )
+        logger.info("Log sheet template '%s' stored.", filename)
 
     def get_weather_collection(self) -> Collection:
         """Get the weather collection from the database.

--- a/src/log_keeper/output.py
+++ b/src/log_keeper/output.py
@@ -4,14 +4,150 @@ This file handles outputting the master log to excel and MongoDB Atlas.
 """
 
 # Standard library imports.
+import re
+import zipfile
+from datetime import date, datetime
+from io import BytesIO
 from pathlib import Path
+from xml.sax.saxutils import escape
+
 import pandas as pd
-from datetime import datetime
 from pymongo import DeleteMany, UpdateOne
 
 # User defined modules.
 from log_keeper import logger
 from log_keeper.get_config import Database
+
+# 2965D template pre-fill constants.
+EXCEL_EPOCH = date(1899, 12, 30)
+MINUTES_PER_DAY = 1440
+TEMPLATE_SHEET_NAME = "2965D"
+# Header cells filled on the 2965D sheet.
+CELL_AIRCRAFT = "F2"
+CELL_DATE = "O2"
+CELL_HOURS_BF = "C4"
+CELL_LAUNCHES_BF = "C5"
+# Content type of a .xltx workbook part vs a normal .xlsx workbook part.
+TEMPLATE_CONTENT_TYPE = (
+    "application/vnd.openxmlformats-officedocument." "spreadsheetml.template.main+xml"
+)
+WORKBOOK_CONTENT_TYPE = (
+    "application/vnd.openxmlformats-officedocument." "spreadsheetml.sheet.main+xml"
+)
+
+
+def _set_cell(sheet_xml: str, ref: str, inner: str, extra_attr: str = "") -> str:
+    """Inject a value into a worksheet cell, preserving its existing style.
+
+    Args:
+        sheet_xml (str): The worksheet XML.
+        ref (str): The cell reference, e.g. "C4".
+        inner (str): XML to place inside the cell, e.g. "<v>1234</v>".
+        extra_attr (str): Extra opening-tag attributes, e.g. ' t="inlineStr"'.
+
+    Returns:
+        str: The worksheet XML with the cell populated."""
+    pattern = re.compile(
+        r'<c r="%s"((?: [a-zA-Z:]+="[^"]*")*)\s*(?:/>|>.*?</c>)' % re.escape(ref),
+        re.DOTALL,
+    )
+
+    def repl(match: re.Match) -> str:
+        # Drop any existing type (e.g. shared-string) attribute, then add ours.
+        attrs = re.sub(r' t="[^"]*"', "", match.group(1))
+        return f'<c r="{ref}"{attrs}{extra_attr}>{inner}</c>'
+
+    new_xml, count = pattern.subn(repl, sheet_xml, count=1)
+    if count != 1:
+        raise ValueError(
+            f"Cell {ref} not found in the template's " f"{TEMPLATE_SHEET_NAME} sheet."
+        )
+    return new_xml
+
+
+def fill_log_sheet(
+    template_bytes: bytes,
+    aircraft: str,
+    launches_bf,
+    hours_bf_minutes,
+    sheet_date: date,
+) -> bytes:
+    """Pre-fill a 2965D template's header cells, preserving everything else.
+
+    Args:
+        template_bytes (bytes): The stored template (.xltx/.xlsx) file.
+        aircraft (str): Aircraft number, e.g. "ZE683" (cell F2).
+        launches_bf (int | None): Launches brought forward (C5); blank if None.
+        hours_bf_minutes (int | None): Hours brought forward in minutes (C4),
+            written as an Excel duration; blank if None.
+        sheet_date (date): Date of the log sheet (O2).
+
+    Returns:
+        bytes: The filled .xlsx file."""
+    # An xlsx is a zip of XML; patch 4 cells, copy the rest byte-for-byte.
+    # (openpyxl would drop the form controls, image and drop-downs on save.)
+    with zipfile.ZipFile(BytesIO(template_bytes)) as zin:
+        # Locate the 2965D sheet's file: name -> rId (workbook) -> filename.
+        workbook = zin.read("xl/workbook.xml").decode("utf-8")
+        rid = re.search(
+            r'<sheet[^>]*name="%s"[^>]*r:id="([^"]+)"' % TEMPLATE_SHEET_NAME,
+            workbook,
+        )
+        if not rid:
+            raise ValueError(
+                f'"{TEMPLATE_SHEET_NAME}" sheet not found in the template.'
+            )
+        rels = zin.read("xl/_rels/workbook.xml.rels").decode("utf-8")
+        target = re.search(
+            r'<Relationship[^>]*Id="%s"[^>]*Target="([^"]+)"' % rid.group(1),
+            rels,
+        )
+        if not target:
+            # Clear error instead of an AttributeError on a malformed template.
+            raise ValueError(
+                f"Relationship {rid.group(1)} for the "
+                f"{TEMPLATE_SHEET_NAME} sheet is missing from the template."
+            )
+        sheet_path = "xl/" + target.group(1).lstrip("/")
+
+        # Fill F2=aircraft, O2=date serial, C4=hours (mins/1440), C5=launches.
+        # Each keeps its cell style; C4/C5 skipped when unknown (left blank).
+        sheet_xml = zin.read(sheet_path).decode("utf-8")
+        sheet_xml = _set_cell(
+            sheet_xml,
+            CELL_AIRCRAFT,
+            f"<is><t>{escape(aircraft)}</t></is>",
+            ' t="inlineStr"',
+        )
+        sheet_xml = _set_cell(
+            sheet_xml, CELL_DATE, f"<v>{(sheet_date - EXCEL_EPOCH).days}</v>"
+        )
+        if hours_bf_minutes is not None:
+            sheet_xml = _set_cell(
+                sheet_xml, CELL_HOURS_BF, f"<v>{hours_bf_minutes / MINUTES_PER_DAY}</v>"
+            )
+        if launches_bf is not None:
+            sheet_xml = _set_cell(
+                sheet_xml, CELL_LAUNCHES_BF, f"<v>{int(launches_bf)}</v>"
+            )
+
+        # Mark as a workbook so Excel opens it editable, not as a copy.
+        content_types = (
+            zin.read("[Content_Types].xml")
+            .decode("utf-8")
+            .replace(TEMPLATE_CONTENT_TYPE, WORKBOOK_CONTENT_TYPE)
+        )
+
+        # Copy all parts; swap in only the 2 edited ones.
+        edited = {
+            sheet_path: sheet_xml.encode("utf-8"),
+            "[Content_Types].xml": content_types.encode("utf-8"),
+        }
+        buffer = BytesIO()
+        with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as zout:
+            for item in zin.infolist():
+                zout.writestr(item, edited.get(item.filename, zin.read(item.filename)))
+    return buffer.getvalue()
 
 
 def launches_to_excel(launches_df, output_file_path):
@@ -22,27 +158,21 @@ def launches_to_excel(launches_df, output_file_path):
 
     # Create the excel file and table.
     try:
-        writer = pd.ExcelWriter(output_file_path, engine='xlsxwriter')
+        writer = pd.ExcelWriter(output_file_path, engine="xlsxwriter")
     except Exception:
         # Writing to MASTER_LOG didn't work. We will need to create a temp
         # file to copy and paste.
-        logger.warning(
-            "Could not write to MASTER_LOG.xlsx. Saving to temp file."
-        )
+        logger.warning("Could not write to MASTER_LOG.xlsx. Saving to temp file.")
         # Get new path using todays date.
-        date = datetime.today().strftime('%y%m%d')
-        output_file_path = output_file_path.with_suffix('')
-        output_file_path = Path(str(output_file_path) + '-' + date + '.xlsx')
+        date = datetime.today().strftime("%y%m%d")
+        output_file_path = output_file_path.with_suffix("")
+        output_file_path = Path(str(output_file_path) + "-" + date + ".xlsx")
         logger.info("Writing to %s", output_file_path.name)
-        writer = pd.ExcelWriter(output_file_path, engine='xlsxwriter')
+        writer = pd.ExcelWriter(output_file_path, engine="xlsxwriter")
 
     # Write the dataframe to the Excel file.
     launches_df.to_excel(
-        writer,
-        sheet_name=SHEET_NAME,
-        index=False,
-        header=False,
-        startrow=1
+        writer, sheet_name=SHEET_NAME, index=False, header=False, startrow=1
     )
 
     # Get the xlsxwriter workbook and worksheet objects.
@@ -50,15 +180,18 @@ def launches_to_excel(launches_df, output_file_path):
     worksheet = writer.sheets[SHEET_NAME]
 
     # Get the dimensions of the dataframe.
-    (max_row, max_col) = launches_df.shape
+    max_row, max_col = launches_df.shape
 
     # Create a list of column headers, to use in add_table().
     column_settings = [{"header": column} for column in launches_df.columns]
 
     # Add the Excel table structure. Pandas will add the data.
     worksheet.add_table(
-        0, 0, max_row, max_col - 1,
-        {"columns": column_settings, 'style': 'Table Style Medium 1'}
+        0,
+        0,
+        max_row,
+        max_col - 1,
+        {"columns": column_settings, "style": "Table Style Medium 1"},
     )
 
     # Make the columns wider for clarity.
@@ -66,9 +199,7 @@ def launches_to_excel(launches_df, output_file_path):
 
     # Change the format of the 'Date' column to 'dd/mm/yyyy'.
     date_column = launches_df.columns.get_loc("Date")
-    date_format = workbook.add_format(
-        {'num_format': 'dd/mm/yyyy'}
-    )  # type: ignore
+    date_format = workbook.add_format({"num_format": "dd/mm/yyyy"})  # type: ignore
     worksheet.set_column(date_column, date_column, 10, date_format)
 
     # Close the Pandas Excel writer and output the Excel file.
@@ -89,7 +220,7 @@ def backup_launches_collection(db: Database):
 
     # Backup the old collection with today's date as the suffix.
     # Get today's date as YYMMDD.
-    today = datetime.today().strftime('%y%m%d')
+    today = datetime.today().strftime("%y%m%d")
 
     # Create collection search string.
     collection_search_string = f"{db.launches_collection}_{today}"
@@ -99,10 +230,12 @@ def backup_launches_collection(db: Database):
         db.db.drop_collection(collection_search_string)
 
     # Use aggregation with $out to backup the collection.
-    db.get_launches_collection().aggregate([
-        {"$match": {}},
-        {"$out": collection_search_string},
-    ])
+    db.get_launches_collection().aggregate(
+        [
+            {"$match": {}},
+            {"$out": collection_search_string},
+        ]
+    )
 
 
 def launches_to_db(launches_df, db: Database):
@@ -116,7 +249,7 @@ def launches_to_db(launches_df, db: Database):
     backup_launches_collection(db=db)
 
     # Format dataframe to be saved.
-    master_dict = launches_df.to_dict('records')
+    master_dict = launches_df.to_dict("records")
 
     # Save to the DB.
     logger.info("Saving to DB.")
@@ -144,7 +277,7 @@ def update_launches_collection(launches_df, db: Database):
     collection = db.get_launches_collection()
 
     # Group by date and aircraft.
-    grouped = launches_df.groupby(['Date', 'Aircraft'])
+    grouped = launches_df.groupby(["Date", "Aircraft"])
 
     # Prepare bulk delete and inset operations.
     delete_ops = []
@@ -168,14 +301,18 @@ def update_launches_collection(launches_df, db: Database):
 
     # Delete the records if they exist.
     if delete_ops:
-        logger.info("Deleting %.0f launches from %.0f days/aircraft.",
-                    deleted_launches, len(delete_ops))
+        logger.info(
+            "Deleting %.0f launches from %.0f days/aircraft.",
+            deleted_launches,
+            len(delete_ops),
+        )
         collection.bulk_write(delete_ops)
 
     # Step 2: Insert all the records.
-    documents = launches_df.to_dict('records')
-    logger.info("Inserting %.0f launches from %.0f days/aircraft.",
-                len(documents), len(grouped))
+    documents = launches_df.to_dict("records")
+    logger.info(
+        "Inserting %.0f launches from %.0f days/aircraft.", len(documents), len(grouped)
+    )
     collection.insert_many(documents)
 
 
@@ -190,7 +327,7 @@ def backup_aircraft_info_collection(db: Database):
 
     # Backup the old collection with today's date as the suffix.
     # Get today's date as YYMMDD.
-    today = datetime.today().strftime('%y%m%d')
+    today = datetime.today().strftime("%y%m%d")
 
     # Create collection search string.
     collection_search_string = f"{db.aircraft_info_collection}_{today}"
@@ -201,10 +338,12 @@ def backup_aircraft_info_collection(db: Database):
         db.db.drop_collection(collection_search_string)
 
         # Use aggregation with $out to backup the collection.
-        db.get_aircraft_info_collection().aggregate([
-            {"$match": {}},
-            {"$out": collection_search_string},
-        ])
+        db.get_aircraft_info_collection().aggregate(
+            [
+                {"$match": {}},
+                {"$out": collection_search_string},
+            ]
+        )
 
 
 def update_aircraft_info(aircraft_info: pd.DataFrame, db: Database):
@@ -226,7 +365,7 @@ def update_aircraft_info(aircraft_info: pd.DataFrame, db: Database):
     collection = db.get_aircraft_info_collection()
 
     # Group by aircraft.
-    grouped = aircraft_info.groupby(['Aircraft', 'Date'])
+    grouped = aircraft_info.groupby(["Aircraft", "Date"])
 
     # Prepare bulk delete and insert operations.
     delete_ops = []
@@ -253,7 +392,7 @@ def update_aircraft_info(aircraft_info: pd.DataFrame, db: Database):
         collection.bulk_write(delete_ops)
 
     # Step 2: Insert all the records.
-    documents = aircraft_info.to_dict('records')
+    documents = aircraft_info.to_dict("records")
     logger.info("Inserting %.0f aircraft info records.", len(documents))
     collection.insert_many(documents)
 
@@ -287,20 +426,15 @@ def weather_to_db(weather_df: pd.DataFrame, db: Database):
         }
 
         # Create update operation
-        bulk_operations.append(
-            UpdateOne(
-                query,
-                {"$set": doc},
-                upsert=True
-            )
-        )
+        bulk_operations.append(UpdateOne(query, {"$set": doc}, upsert=True))
 
     # Execute bulk operations
     if bulk_operations:
         result = collection.bulk_write(bulk_operations)
         logger.info(
             "Weather data updated: %d records modified, %d records upserted.",
-            result.modified_count, result.upserted_count
+            result.modified_count,
+            result.upserted_count,
         )
     else:
         logger.info("No weather data to update.")

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -184,10 +184,11 @@ def test_navigation_to_upload_page(page: Page):
 
     # Navigate to upload page
     page.locator("div").filter(has_text=re.compile(r"^📈 Statistics$")).first.click()
-    page.get_by_text("📁 Upload Log Sheets").click()
+    page.get_by_text("📁 Log Sheets").click()
 
-    # Verify upload page loaded
-    expect(page.get_by_test_id("stFileUploaderDropzone")).to_be_visible()
+    # Verify upload page loaded. The page has two uploaders (template +
+    # completed log sheets); the completed-log-sheets one renders last.
+    expect(page.get_by_test_id("stFileUploaderDropzone").last).to_be_visible()
 
 
 def navigate_to_stats_gur_page(page: Page) -> None:
@@ -302,12 +303,12 @@ def test_file_upload_valid(page: Page):
 
     # Navigate to upload page
     page.locator("div").filter(has_text=re.compile(r"^📈 Statistics$")).first.click()
-    page.get_by_text("📁 Upload Log Sheets").click()
-    expect(page.get_by_test_id("stFileUploaderDropzone")).to_be_visible()
+    page.get_by_text("📁 Log Sheets").click()
+    expect(page.get_by_test_id("stFileUploaderDropzone").last).to_be_visible()
 
-    # Upload valid file
+    # Upload valid file to the completed-log-sheets uploader (the last one).
     valid_file = "tests/fixtures/2965D_260214_ZE633.xlsx"
-    page.set_input_files("input[type='file']", [valid_file])
+    page.locator("input[type='file']").last.set_input_files([valid_file])
 
     # Assert success message appears in toast notification
     expect(
@@ -321,12 +322,12 @@ def test_file_upload_invalid(page: Page):
 
     # Navigate to upload page
     page.locator("div").filter(has_text=re.compile(r"^📈 Statistics$")).first.click()
-    page.get_by_text("📁 Upload Log Sheets").click()
-    expect(page.get_by_test_id("stFileUploaderDropzone")).to_be_visible()
+    page.get_by_text("📁 Log Sheets").click()
+    expect(page.get_by_test_id("stFileUploaderDropzone").last).to_be_visible()
 
     # Upload invalid xlsx file (has .xlsx extension but is not a valid Excel file)
     invalid_file = "tests/fixtures/invalid.xlsx"
-    page.set_input_files("input[type='file']", [invalid_file])
+    page.locator("input[type='file']").last.set_input_files([invalid_file])
 
     # Assert warning message appears indicating the log sheet is invalid
     expect(

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,17 +1,27 @@
 """test_output.py - Test cases for the output module."""
 
+import zipfile
 import pytest
 import pandas as pd
+import openpyxl
+from io import BytesIO
+from pathlib import Path
 from unittest.mock import MagicMock, patch
-from datetime import datetime
+from datetime import datetime, date, timedelta
 
 from log_keeper.output import (
     launches_to_excel,
     backup_launches_collection,
     launches_to_db,
     update_launches_collection,
-    update_aircraft_info
+    update_aircraft_info,
+    fill_log_sheet,
 )
+
+TEMPLATE_FIXTURE = Path(__file__).parent / "fixtures" / "2965D_260214_ZE633.xlsx"
+# The repo's docs/ template is the empty scaffold (blank header cells).
+EMPTY_TEMPLATE = (Path(__file__).parent.parent / "docs"
+                  / "2965D_YYMMDD_ZEXXX.xltx")
 
 
 @pytest.fixture
@@ -119,3 +129,43 @@ def test_update_aircraft_info(mock_db, sample_aircraft_info):
     # Test with empty DataFrame
     update_aircraft_info(pd.DataFrame(), mock_db)
     assert collection.bulk_write.call_count == 1  # Should not increase
+
+
+def test_fill_log_sheet():
+    """fill_log_sheet pre-fills the header cells and preserves the workbook."""
+    src = TEMPLATE_FIXTURE.read_bytes()
+    out = fill_log_sheet(src, "ZE683", launches_bf=1234,
+                         hours_bf_minutes=74070, sheet_date=date(2026, 6, 30))
+
+    # Every other zip part (form controls, drawings, tables) is preserved.
+    n_src = len(zipfile.ZipFile(BytesIO(src)).infolist())
+    n_out = len(zipfile.ZipFile(BytesIO(out)).infolist())
+    assert n_out == n_src
+
+    # The download is a real workbook, not a template Excel opens as a copy.
+    content_types = zipfile.ZipFile(BytesIO(out)).read(
+        "[Content_Types].xml").decode("utf-8")
+    assert "sheet.main+xml" in content_types
+    assert "template.main+xml" not in content_types
+
+    # The four header cells are filled (C4 as an exact [h]:mm duration).
+    ws = openpyxl.load_workbook(BytesIO(out))["2965D"]
+    assert ws["F2"].value == "ZE683"
+    assert ws["O2"].value == datetime(2026, 6, 30)
+    assert ws["C4"].value == timedelta(minutes=74070)
+    assert ws["C5"].value == 1234
+
+    # The hidden sheets the ingest pipeline relies on still parse.
+    with pd.ExcelFile(BytesIO(out)) as xls:
+        assert {"FORMATTED", "_AIRCRAFT"} <= set(xls.sheet_names)
+
+
+def test_fill_log_sheet_blank_brought_forward():
+    """With no brought-forward data, C4/C5 are left blank."""
+    out = fill_log_sheet(EMPTY_TEMPLATE.read_bytes(), "ZE557",
+                         launches_bf=None, hours_bf_minutes=None,
+                         sheet_date=date(2026, 6, 30))
+    ws = openpyxl.load_workbook(BytesIO(out))["2965D"]
+    assert ws["F2"].value == "ZE557"
+    assert ws["C4"].value is None
+    assert ws["C5"].value is None


### PR DESCRIPTION
## Description

Closes #138 

This allows the user to download a pre-filled 2965D (log sheet) with aircraft details, the correct name (`2965D_260630_ZE666.xlsx`), and the current date filled in so its ready-to-go in the morning. No more dicking about with the template! Just save-as in the Log Sheets folder on sharepoint and fly.

## Test plan

- [x] Deploy to streamlit
- [x] Upload a template (our template)
- [x] Download a pre-filled log sheet for ZE683
- [x] Download a log sheet for a new aircraft that we don't have (ZE666)

## Evidence

[Kooha-2026-06-30-17-02-42.webm](https://github.com/user-attachments/assets/fbcd58ab-5f56-4575-8390-680d4d8326e2)
