### PR TITLE
144 pagination

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ pymongo[srv]~=4.17.0
 requests-cache~=1.3.2
 retry-requests~=2.0.0
 secretstorage~=3.5.0
-streamlit~=1.57.0
+streamlit~=1.58.0
 tqdm~=4.67.3
 xlsxwriter~=3.2.9
 

--- a/src/dashboard/main.py
+++ b/src/dashboard/main.py
@@ -31,6 +31,8 @@ from dashboard.plots import (   # noqa: E402
     generate_aircraft_daily_summary,
     show_single_metrics,
     show_logo,
+    show_login_hero,
+    show_dashboard_header,
     aircraft_flown_per_day,
     launches_daily_summary,
     table_gifs_per_date,
@@ -251,7 +253,7 @@ def show_data_dashboard(db: Database):
     # Set the page title.
     logger.info("Displaying %s dashboard.", db.database_name)
     vgs = db.database_name.upper()
-    st.title(f"{vgs} Dashboard")
+    show_dashboard_header(LOGO_PATH, f"{vgs} Dashboard")
 
     # Get dataframe of launches and aircraft info.
     if "df" not in st.session_state:
@@ -514,6 +516,9 @@ def authenticate():
 
     if st.session_state["authenticated"]:
         return
+
+    # Login screen only: full-size branding above the form.
+    show_login_hero(LOGO_PATH)
 
     # Login form.
     with st.form(key="login_form"):

--- a/src/dashboard/main.py
+++ b/src/dashboard/main.py
@@ -8,6 +8,7 @@ import subprocess
 import streamlit as st
 import pandas as pd
 from pathlib import Path
+from urllib.parse import urlparse
 
 # Ensure the src directory is in the sys.path.
 src_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
@@ -413,7 +414,9 @@ def show_data_dashboard(db: Database):
     all_data = st.Page(all_data_page, title="All Data", icon="🌍")
 
     # Sidebar nav; order preserved from the old selectbox.
-    nav = st.navigation([stats, logs, gur, weather, all_data])
+    pages = [stats, logs, gur, weather, all_data]
+    nav = st.navigation(pages)
+    _restore_requested_page(nav, pages)
     nav.run()
 
 
@@ -653,11 +656,33 @@ def configure_app(LOGO_PATH: Path):
     )
 
 
+def _capture_requested_page():
+    """Stash a deep-link page path before the login gate discards it."""
+    if "_requested_page" in st.session_state:
+        return
+    st.session_state["_requested_page"] = (
+        urlparse(st.context.url).path.rstrip("/").rsplit("/", 1)[-1]
+    )
+
+
+def _restore_requested_page(nav, pages):
+    """Switch to a deep link captured before login; consumed once."""
+    requested = st.session_state.pop("_requested_page", None)
+    if not requested:
+        return
+    target = next((p for p in pages if p.url_path == requested), None)
+    if target and target.url_path != nav.url_path:
+        st.switch_page(target)
+
+
 def main():
     """Main Streamlit App Code."""
     # Confiure the Streamlit app.
     configure_app(LOGO_PATH)
     show_logo(LOGO_PATH)
+
+    # Deep links are lost during the login reruns unless captured now.
+    _capture_requested_page()
 
     # Cookie manager used to persist the login across page refreshes.
     # Invariant: at most ONE cookie write (set/clear) per completing run - a

--- a/src/dashboard/main.py
+++ b/src/dashboard/main.py
@@ -167,13 +167,14 @@ def refresh_data():
     st.toast("Data Refreshed!", icon="✅")
 
 
-def show_log_sheets_page(db: Database, aircraft_df: pd.DataFrame):
+def show_log_sheets_page(db: Database, aircraft_df: pd.DataFrame, redirect_page):
     """Render Log Sheets page: pre-filled download, template update and sheet upload.
 
     Args:
         db (Database): The VGS database class.
         aircraft_df (pd.DataFrame): Aircraft info for the brought-forward
-            lookup and the aircraft drop-down."""
+            lookup and the aircraft drop-down.
+        redirect_page (st.Page): Page to switch to after a successful upload."""
     # Download a pre-filled 2965D for a chosen aircraft.
     st.subheader("⬇️ Download pre-filled log sheet")
     if not aircraft_df.empty:
@@ -237,11 +238,9 @@ def show_log_sheets_page(db: Database, aircraft_df: pd.DataFrame):
         # Upload the log sheets and refresh data.
         success = upload_log_sheets(files)
         refresh_data()
-        # Only redirect on a successful upload.
+        # Jump to the stats page on a successful upload.
         if success:
-            # Flag a redirect to the stats page.
-            st.session_state["redirect_to_stats"] = True
-            st.rerun()
+            st.switch_page(redirect_page)
 
 
 def show_data_dashboard(db: Database):
@@ -253,14 +252,6 @@ def show_data_dashboard(db: Database):
     logger.info("Displaying %s dashboard.", db.database_name)
     vgs = db.database_name.upper()
     st.title(f"{vgs} Dashboard")
-
-    # Sidebar for page navigation
-    pages = ["📈 Statistics", "📁 Log Sheets",
-             "🧮 Stats & GUR Helper", "⛅ Weather", "🌍 All Data"]
-    # Honour a redirect after a log sheet upload before the widget is instantiated.
-    if st.session_state.pop("redirect_to_stats", False):
-        st.session_state["select_page"] = "🧮 Stats & GUR Helper"
-    page = st.selectbox("Select a Page:", pages, key="select_page")
 
     # Get dataframe of launches and aircraft info.
     if "df" not in st.session_state:
@@ -307,103 +298,121 @@ def show_data_dashboard(db: Database):
     # Combine CGS launches if the user flew there, then apply the same filter
     personal_df = get_personal_df(filtered_df, st.session_state["client"])
 
-    match page:
-        case "📈 Statistics":
-            # Refresh data button.
-            if st.button("🔃 Refresh Data", key="refresh"):
-                refresh_data()
+    # Pages are callables sharing the filter state computed above.
+    def statistics_page():
+        """Render the Statistics page."""
+        # Refresh data button.
+        if st.button("🔃 Refresh Data", key="refresh"):
+            refresh_data()
 
-            # Display metrics for financial year.
-            show_single_metrics(filtered_df)
+        # Display metrics for financial year.
+        show_single_metrics(filtered_df)
 
+        left, right = st.columns(2, gap="medium")
+        with left:
+            # Plot the number of launches by unique AircraftCommander.
+            plot_launches_by_commander(filtered_df)
+        with right:
+            # Plot the ten unique longest flight times
+            plot_longest_flight_times(filtered_df)
+            # Plot the pie chart to show launches per duty
+            plot_duty_pie_chart(filtered_df)
+
+        # Plot the number of launches per month
+        plot_monthly_launches(filtered_df)
+
+        # Plot number of GIFs flown.
+        plot_gif_bar_chart(filtered_df)
+
+        # Logbook helper by AircraftCommander.
+        show_logbook_helper(personal_df, commander)
+        # Show CGS match info if applicable
+        if (
+            commander
+            and "cgs_match_count" in st.session_state
+            and commander in st.session_state["cgs_match_count"]
+        ):
+            match_count = st.session_state["cgs_match_count"][commander]
+            if match_count > 0:
+                st.info(f"CGS launches for {commander}: {match_count}")
+
+        # Show solo/dual launch summary for selected pilot
+        table_solo_dual_summary(personal_df, commander)
+
+        # Filter the data by the selected quarter.
+        if quarter and commander:
+            quarter_personal_df = get_personal_df(
+                filtered_df=df,
+                client=st.session_state["client"]
+            )
+            quarterly_summary(quarter_personal_df, commander, quarter)
+
+    def all_data_page():
+        """Render the All Data page."""
+        # Plot all launches. Filter by AircraftCommander and date if
+        # selected.
+        if commander:
+            commander_df = filtered_df[
+                filtered_df['AircraftCommander'] == commander
+            ]
+        else:
+            commander_df = filtered_df
+        table_all_launches(commander_df)
+
+    def stats_gur_page():
+        """Render the Stats & GUR Helper page."""
+        # Show statistics and glider utilisation return helpers.
+        # Stats helpers.
+        st.header("Stats Helpers")
+
+        # Stats return - summarise the last flying day by default.
+        ops_form_helper(df)
+
+        # Hide the detailed tables behind a toggle.
+        if st.toggle("Show more stats", key="more_stats_shown"):
             left, right = st.columns(2, gap="medium")
             with left:
-                # Plot the number of launches by unique AircraftCommander.
-                plot_launches_by_commander(filtered_df)
+                # Show the first and last launch time table.
+                plot_firstlast_launch_table(filtered_df)
+                # Show number of GIFs flown by day.
+                table_gifs_per_date(filtered_df)
             with right:
-                # Plot the ten unique longest flight times
-                plot_longest_flight_times(filtered_df)
-                # Plot the pie chart to show launches per duty
-                plot_duty_pie_chart(filtered_df)
+                # Show launches by sortie type.
+                launches_by_type_table(filtered_df)
 
-            # Plot the number of launches per month
-            plot_monthly_launches(filtered_df)
+        # GUR helpers.
+        st.divider()
+        st.header("GUR Helpers")
+        table_gur_summary(aircraft_df, df)
+        left, right = st.columns(2, gap="medium")
+        with left:
+            table_aircraft_totals(aircraft_df)
+            table_aircraft_weekly_summary(filtered_df)
+            aircraft_flown_per_day(filtered_df)
+        with right:
+            generate_aircraft_daily_summary(filtered_df)
+            launches_daily_summary(filtered_df)
 
-            # Plot number of GIFs flown.
-            plot_gif_bar_chart(filtered_df)
+    def log_sheets_page():
+        """Render the Log Sheets page."""
+        show_log_sheets_page(db, aircraft_df, gur)
 
-            # Logbook helper by AircraftCommander.
-            show_logbook_helper(personal_df, commander)
-            # Show CGS match info if applicable
-            if (
-                commander
-                and "cgs_match_count" in st.session_state
-                and commander in st.session_state["cgs_match_count"]
-            ):
-                match_count = st.session_state["cgs_match_count"][commander]
-                if match_count > 0:
-                    st.info(f"CGS launches for {commander}: {match_count}")
+    def weather_view():
+        """Render the Weather page."""
+        weather_page(db, filtered_df)
 
-            # Show solo/dual launch summary for selected pilot
-            table_solo_dual_summary(personal_df, commander)
+    # Build page objects; title required for callables, emojis kept as icons.
+    # Distinct callables (not lambdas) give each page a unique URL pathname.
+    stats = st.Page(statistics_page, title="Statistics", icon="📈",
+                    default=True)
+    gur = st.Page(stats_gur_page, title="Stats & GUR Helper", icon="🧮")
+    logs = st.Page(log_sheets_page, title="Log Sheets", icon="📁")
+    weather = st.Page(weather_view, title="Weather", icon="⛅")
+    all_data = st.Page(all_data_page, title="All Data", icon="🌍")
 
-            # Filter the data by the selected quarter.
-            if quarter and commander:
-                personal_df = get_personal_df(
-                    filtered_df=df,
-                    client=st.session_state["client"]
-                )
-                quarterly_summary(personal_df, commander, quarter)
-
-        case "🌍 All Data":
-            # Plot all launches. Filter by AircraftCommander and date if
-            # selected.
-            if commander:
-                commander_df = filtered_df[
-                    filtered_df['AircraftCommander'] == commander
-                ]
-            else:
-                commander_df = filtered_df
-            table_all_launches(commander_df)
-
-        case "🧮 Stats & GUR Helper":
-            # Show statistics and glider utilisation return helpers.
-            # Stats helpers.
-            st.header("Stats Helpers")
-
-            # Stats return - summarise the last flying day by default.
-            ops_form_helper(df)
-
-            # Hide the detailed tables behind a toggle.
-            if st.toggle("Show more stats", key="more_stats_shown"):
-                left, right = st.columns(2, gap="medium")
-                with left:
-                    # Show the first and last launch time table.
-                    plot_firstlast_launch_table(filtered_df)
-                    # Show number of GIFs flown by day.
-                    table_gifs_per_date(filtered_df)
-                with right:
-                    # Show launches by sortie type.
-                    launches_by_type_table(filtered_df)
-
-            # GUR helpers.
-            st.divider()
-            st.header("GUR Helpers")
-            table_gur_summary(aircraft_df, df)
-            left, right = st.columns(2, gap="medium")
-            with left:
-                table_aircraft_totals(aircraft_df)
-                table_aircraft_weekly_summary(filtered_df)
-                aircraft_flown_per_day(filtered_df)
-            with right:
-                generate_aircraft_daily_summary(filtered_df)
-                launches_daily_summary(filtered_df)
-
-        case "⛅ Weather":
-            weather_page(db, filtered_df)
-
-        case "📁 Log Sheets":
-            show_log_sheets_page(db, aircraft_df)
+    # Sidebar nav; order preserved from the old selectbox.
+    nav = st.navigation([stats, logs, gur, weather, all_data])
+    nav.run()
 
 
 def login(username: str, password: str):

--- a/src/dashboard/plots.py
+++ b/src/dashboard/plots.py
@@ -1,6 +1,7 @@
 """plots.py - Create plots for the dashboard"""
 
 # Get packages.
+import base64
 from pathlib import Path
 
 import altair as alt
@@ -750,19 +751,51 @@ def show_single_metrics(df: pd.DataFrame):
 
 
 def show_logo(logo_path: Path):
-    """Add the logo to the page.
+    """Add the persistent brand mark to the sidebar.
 
     Args:
         logo_path (Path): The path to the logo.
     """
     st.logo(str(logo_path))
+
+
+def show_login_hero(logo_path: Path):
+    """Show the large centred logo and title on the login screen.
+
+    Args:
+        logo_path (Path): The path to the logo.
+    """
     _, centre, _ = st.columns(3)
     with centre:
         st.image(str(logo_path), width="stretch")
 
-    # Show centred text.
+    # Centred title, shown only before login.
     st.markdown(
-        "<h2 style='text-align: center;'>" "Volunteer Gliding Squadron Dashboard</h1>",
+        "<h2 style='text-align: center;'>Volunteer Gliding Squadron Dashboard</h2>",
+        unsafe_allow_html=True,
+    )
+
+
+@st.cache_data(show_spinner=False)
+def _logo_data_uri(logo_path: str) -> str:
+    """Return the logo as a base64 PNG data URI (cached across reruns).
+
+    Args:
+        logo_path (str): The path to the logo."""
+    encoded = base64.b64encode(Path(logo_path).read_bytes()).decode()
+    return f"data:image/png;base64,{encoded}"
+
+
+def show_dashboard_header(logo_path: Path, title: str):
+    """Show the dashboard title with the logo inline to its left.
+
+    Args:
+        logo_path (Path): The path to the logo.
+        title (str): The dashboard title text."""
+    st.markdown(
+        f"<h1 style='display: flex; align-items: center; gap: 0.6rem;'>"
+        f"<img src='{_logo_data_uri(str(logo_path))}' alt='' "
+        f"style='height: 3rem;'/> {title}</h1>",
         unsafe_allow_html=True,
     )
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -160,6 +160,19 @@ def login_user(page: Page) -> None:
         expect(heading).to_be_visible(timeout=20000)
 
 
+def wait_for_idle(page: Page) -> None:
+    """Wait for Streamlit to finish rerunning so the DOM is stable.
+
+    Args:
+        page: Playwright page instance."""
+    try:
+        expect(page.get_by_test_id("stStatusWidget")).to_be_hidden(
+            timeout=15000
+        )
+    except AssertionError:
+        pass
+
+
 def open_page(page: Page, name: str) -> None:
     """Open a page from the sidebar navigation.
 
@@ -167,6 +180,7 @@ def open_page(page: Page, name: str) -> None:
         page: Playwright page instance.
         name: The page's nav label, e.g. "Log Sheets"."""
     page.get_by_test_id("stSidebarNav").get_by_role("link", name=name).click()
+    wait_for_idle(page)
 
 
 #####################################################################
@@ -326,9 +340,12 @@ def test_weather_variable_selection(page: Page):
 
     # Change weather variable
     page.locator("div").filter(has_text=re.compile(r"^Wind Speed$")).first.click()
-    page.get_by_role("option", name="Wind Direction").click()
+    option = page.get_by_role("option", name="Wind Direction")
+    expect(option).to_be_visible()
+    option.click()
 
     # Verify change was applied (page should not error)
+    wait_for_idle(page)
     expect(page.get_by_role("heading", name="Weather Summary")).to_be_visible()
 
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -154,6 +154,15 @@ def login_user(page: Page) -> None:
     )
 
 
+def open_page(page: Page, name: str) -> None:
+    """Open a page from the sidebar navigation.
+
+    Args:
+        page: Playwright page instance.
+        name: The page's nav label, e.g. "Log Sheets"."""
+    page.get_by_test_id("stSidebarNav").get_by_role("link", name=name).click()
+
+
 #####################################################################
 # E2E Test Functions
 #####################################################################
@@ -246,8 +255,7 @@ def test_navigation_to_upload_page(page: Page):
     login_user(page)
 
     # Navigate to upload page
-    page.locator("div").filter(has_text=re.compile(r"^📈 Statistics$")).first.click()
-    page.get_by_text("📁 Log Sheets").click()
+    open_page(page, "Log Sheets")
 
     # Verify upload page loaded. The page has two uploaders (template +
     # completed log sheets); the completed-log-sheets one renders last.
@@ -256,8 +264,7 @@ def test_navigation_to_upload_page(page: Page):
 
 def navigate_to_stats_gur_page(page: Page) -> None:
     """Helper to open the Stats & GUR page."""
-    page.locator("div").filter(has_text=re.compile(r"^📈 Statistics$")).first.click()
-    page.get_by_text("🧮 Stats & GUR Helper").click()
+    open_page(page, "Stats & GUR Helper")
     expect(page.get_by_role("heading", name="Stats Helpers")).to_be_visible(
         timeout=10000
     )
@@ -295,9 +302,8 @@ def test_navigation_to_weather_page(page: Page):
     """Test navigation to weather page."""
     login_user(page)
 
-    # Open Statistics dropdown and navigate to Weather page
-    page.locator("div").filter(has_text=re.compile(r"^📈 Statistics$")).first.click()
-    page.get_by_text("⛅ Weather").click()
+    # Navigate to the Weather page.
+    open_page(page, "Weather")
 
     # Wait for weather page to load
     expect(page.get_by_role("heading", name="Weather Summary")).to_be_visible(
@@ -310,8 +316,7 @@ def test_weather_variable_selection(page: Page):
     login_user(page)
 
     # Navigate to weather page
-    page.locator("div").filter(has_text=re.compile(r"^📈 Statistics$")).first.click()
-    page.get_by_text("⛅ Weather").click()
+    open_page(page, "Weather")
 
     # Change weather variable
     page.locator("div").filter(has_text=re.compile(r"^Wind Speed$")).first.click()
@@ -326,8 +331,7 @@ def test_weather_cache_reload(page: Page):
     login_user(page)
 
     # Navigate to weather page
-    page.locator("div").filter(has_text=re.compile(r"^📈 Statistics$")).first.click()
-    page.get_by_text("⛅ Weather").click()
+    open_page(page, "Weather")
 
     # Click reload button
     page.get_by_test_id("stBaseButton-secondary").click()
@@ -365,8 +369,7 @@ def test_file_upload_valid(page: Page):
     login_user(page)
 
     # Navigate to upload page
-    page.locator("div").filter(has_text=re.compile(r"^📈 Statistics$")).first.click()
-    page.get_by_text("📁 Log Sheets").click()
+    open_page(page, "Log Sheets")
     expect(page.get_by_test_id("stFileUploaderDropzone").last).to_be_visible()
 
     # Upload valid file to the completed-log-sheets uploader (the last one).
@@ -384,8 +387,7 @@ def test_file_upload_invalid(page: Page):
     login_user(page)
 
     # Navigate to upload page
-    page.locator("div").filter(has_text=re.compile(r"^📈 Statistics$")).first.click()
-    page.get_by_text("📁 Log Sheets").click()
+    open_page(page, "Log Sheets")
     expect(page.get_by_test_id("stFileUploaderDropzone").last).to_be_visible()
 
     # Upload invalid xlsx file (has .xlsx extension but is not a valid Excel file)

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -160,19 +160,6 @@ def login_user(page: Page) -> None:
         expect(heading).to_be_visible(timeout=20000)
 
 
-def wait_for_idle(page: Page) -> None:
-    """Wait for Streamlit to finish rerunning so the DOM is stable.
-
-    Args:
-        page: Playwright page instance."""
-    try:
-        expect(page.get_by_test_id("stStatusWidget")).to_be_hidden(
-            timeout=15000
-        )
-    except AssertionError:
-        pass
-
-
 def open_page(page: Page, name: str) -> None:
     """Open a page from the sidebar navigation.
 
@@ -180,7 +167,6 @@ def open_page(page: Page, name: str) -> None:
         page: Playwright page instance.
         name: The page's nav label, e.g. "Log Sheets"."""
     page.get_by_test_id("stSidebarNav").get_by_role("link", name=name).click()
-    wait_for_idle(page)
 
 
 #####################################################################
@@ -338,14 +324,16 @@ def test_weather_variable_selection(page: Page):
     # Navigate to weather page
     open_page(page, "Weather")
 
+    # Wait for the fetch to finish so the post-fetch widgets are stable.
+    expect(
+        page.get_by_text("Weather data fetched successfully.")
+    ).to_be_visible(timeout=15000)
+
     # Change weather variable
     page.locator("div").filter(has_text=re.compile(r"^Wind Speed$")).first.click()
-    option = page.get_by_role("option", name="Wind Direction")
-    expect(option).to_be_visible()
-    option.click()
+    page.get_by_role("option", name="Wind Direction").click()
 
     # Verify change was applied (page should not error)
-    wait_for_idle(page)
     expect(page.get_by_role("heading", name="Weather Summary")).to_be_visible()
 
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -145,13 +145,19 @@ def login_user(page: Page) -> None:
     # Fill login form
     page.get_by_label("Username", exact=True).fill(USERNAME)
     page.get_by_label("Password", exact=True).fill(PASSWORD)
-    page.get_by_test_id("stBaseButton-secondaryFormSubmit").click()
+    submit = page.get_by_test_id("stBaseButton-secondaryFormSubmit")
+    submit.click()
 
-    # Wait for dashboard to load
-    expected_heading = f"{USERNAME.upper()} Dashboard"
-    expect(page.get_by_role("heading", name=expected_heading)).to_be_visible(
-        timeout=20000
-    )
+    # Wait for the dashboard. The first submit is occasionally dropped before
+    # Streamlit's session is ready, so re-submit once if still on the form.
+    heading = page.get_by_role("heading", name=f"{USERNAME.upper()} Dashboard")
+    try:
+        expect(heading).to_be_visible(timeout=20000)
+    except AssertionError:
+        if not page.get_by_test_id("stForm").is_visible():
+            raise
+        submit.click()
+        expect(heading).to_be_visible(timeout=20000)
 
 
 def open_page(page: Page, name: str) -> None:
@@ -195,7 +201,7 @@ def test_complete_login_flow(page: Page):
     expect(page.get_by_role("heading", name=expected_heading)).to_be_visible()
 
     # Verify we can refresh data (confirms dashboard is functional)
-    expect(page.get_by_test_id("stBaseButton-secondary")).to_be_visible()
+    expect(page.get_by_role("button", name="Refresh Data")).to_be_visible()
 
 
 def test_login_persists_after_reload(page: Page):
@@ -244,7 +250,7 @@ def test_dashboard_data_refresh(page: Page):
     login_user(page)
 
     # Click refresh button
-    page.get_by_test_id("stBaseButton-secondary").click()
+    page.get_by_role("button", name="Refresh Data").click()
 
     # Look for success message
     expect(page.get_by_text("Data Refreshed!")).to_be_visible()
@@ -334,7 +340,7 @@ def test_weather_cache_reload(page: Page):
     open_page(page, "Weather")
 
     # Click reload button
-    page.get_by_test_id("stBaseButton-secondary").click()
+    page.get_by_role("button", name="Reset Weather Cache").click()
 
     # Verify reload success message
     expect(page.get_by_text("Weather data fetched successfully.")).to_be_visible(


### PR DESCRIPTION
## Description

Closes #144 

1. Instead of the dropdown to select a page, actual pages are now used. This allows us to navigate **directly to a page** using a URL e.g. the upload page :partying_face: 

https://viking-log-keeper-ehs7ffynisbji2wifqr8f2.streamlit.app/log_sheets_page

<img width="221" height="219" alt="image" src="https://github.com/user-attachments/assets/bbee8405-f77f-467a-b2d9-bd4ec7d0cc1a" />

2. Instead of the large 2FTS crest on every page, its replaced with the smaller header with a crest and "661VGS Dashboard" as its much nicer on mobile browsers

<img width="538" height="211" alt="image" src="https://github.com/user-attachments/assets/d20f7f24-95e0-447f-9a4c-8ccc6285dca8" />
