### PR TITLE
146 release ci failing

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -23,6 +23,7 @@ jobs:
         pip install setuptools wheel twine
     - name: Build and Publish
       env:
+        PACKAGE_VERSION: ${{ github.event.release.tag_name }}
         TWINE_USERNAME: __token__
         TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
       run: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cryptography~=48.0
+cryptography~=50.0.0
 extra-streamlit-components~=0.1.81
 inquirer~=3.4.1
 keyring~=25.7.0
@@ -23,4 +23,4 @@ pytest-mock~=3.15.1
 pytest-playwright~=0.8.0
 python-dotenv~=1.2.2
 ruff~=0.15.14
-setuptools~=82.0.1
+setuptools~=84.0.0

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 """setup.py - This file is used to install the package and its dependencies."""
 
+import os
 import sys
 import shutil
 import logging
@@ -78,7 +79,8 @@ class PostInstallCommand(install):
 def run_setup():
     setup(
         name="viking-log-keeper",
-        version="2.7.0",
+        # Release CI passes the git tag. Local builds are always 0.0.0.dev0.
+        version=(os.environ.get("PACKAGE_VERSION") or "0.0.0.dev0").lstrip("v"),
         packages=find_packages(where="src"),
         package_dir={"": "src"},
         url="https://github.com/mjennings061/viking-log-keeper",


### PR DESCRIPTION
Closes #146
Closes https://github.com/mjennings061/viking-log-keeper/security/dependabot/8
Closes https://github.com/mjennings061/viking-log-keeper/security/dependabot/7

Passing the release version into the build process so the correct version gets uploaded to PyPI. The issue before was it tried to upload 2.7.0 to PyPI but it already existed.. woops.